### PR TITLE
Fix var dumper

### DIFF
--- a/src/Manager/PhpManager.php
+++ b/src/Manager/PhpManager.php
@@ -739,7 +739,7 @@ class PhpManager extends BaseManager
             throw new \RuntimeException(sprintf('Directory "%s" was not created', $concurrentDirectory));
         }
 
-        file_put_contents($file, "<?php\nreturn " . VarDumper::export($data) . ";\n", LOCK_EX);
+        file_put_contents($file, "<?php\nreturn " . VarDumper::create($data)->export() . ";\n", LOCK_EX);
         $this->invalidateScriptCache($file);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | fixed package update problem

"Non-static method Yiisoft\VarDumper\VarDumper::export() should not be called statically"
