### PR TITLE
Replace `getAllChildren()` to `getParents()` in `ItemsStorageInterface`

### DIFF
--- a/src/ItemsStorageInterface.php
+++ b/src/ItemsStorageInterface.php
@@ -54,12 +54,6 @@ interface ItemsStorageInterface
     public function remove(string $name): void;
 
     /**
-     * @return array
-     * @psalm-return array<string,Item[]>
-     */
-    public function getAllChildren(): array;
-
-    /**
      * Returns all roles in the system.
      *
      * @return Role[] All roles in the system.
@@ -103,6 +97,17 @@ interface ItemsStorageInterface
      * All parent child relations will be adjusted accordingly.
      */
     public function clearPermissions(): void;
+
+    /**
+     * Returns the parent permissions and/or roles.
+     *
+     * @param string $name The child name.
+     *
+     * @return Item[] The parent permissions and/or roles.
+     *
+     * @psalm-return array<string,Item>
+     */
+    public function getParents(string $name): array;
 
     /**
      * Returns the child permissions and/or roles.

--- a/tests/Support/FakeItemsStorage.php
+++ b/tests/Support/FakeItemsStorage.php
@@ -53,9 +53,24 @@ final class FakeItemsStorage implements ItemsStorageInterface
         return $this->getItemsByType(Item::TYPE_PERMISSION);
     }
 
-    public function getAllChildren(): array
+    public function getParents(string $name): array
     {
-        return $this->children;
+        $result = [];
+        $this->getParentsRecursive($name, $result);
+        return $result;
+    }
+
+    private function getParentsRecursive(string $name, array &$result): void
+    {
+        foreach ($this->children as $parentName => $items) {
+            foreach ($items as $item) {
+                if ($item->getName() === $name) {
+                    $result[$parentName] = $this->get($parentName);
+                    $this->getParentsRecursive($parentName, $result);
+                    break;
+                }
+            }
+        }
     }
 
     public function getChildren(string $name): array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | #110

Adopt PR: https://github.com/yiisoft/rbac-php/pull/41