### PR TITLE
Exclude parent role from `Manager::getAllChildRoles()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New #161: Add `ManagerInterface` (@arogachev)
 - Chg #161: Raise PHP version to 8.0 (@arogachev)
 - Enh #165: Improve perfomance (@arogachev)
+- Bug #178: Exclude parent role from `Manager::getAllChildRoles()` (@arogachev)
 
 ## 1.0.2 April 20, 2023
 

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -157,12 +157,11 @@ final class Manager implements ManagerInterface
 
     public function getChildRoles(string $roleName): array
     {
-        $role = $this->itemsStorage->getRole($roleName);
-        if ($role === null) {
+        if (!$this->itemsStorage->roleExists($roleName)) {
             throw new InvalidArgumentException("Role \"$roleName\" not found.");
         }
 
-        return array_merge([$roleName => $role], $this->itemsStorage->getAllChildRoles($roleName));
+        return $this->itemsStorage->getAllChildRoles($roleName);
     }
 
     public function getPermissionsByRoleName(string $roleName): array

--- a/src/ManagerInterface.php
+++ b/src/ManagerInterface.php
@@ -119,8 +119,7 @@ interface ManagerInterface extends AccessCheckerInterface
      *
      * @throws InvalidArgumentException If role was not found by `$roleName`.
      *
-     * @return Role[] Child roles. The array is indexed by the role names. First element is an instance of the parent
-     * role itself.
+     * @return Role[] Child roles. The array is indexed by the role names.
      * @psalm-return array<string, Role>
      */
     public function getChildRoles(string $roleName): array;

--- a/tests/Common/ManagerLogicTestTrait.php
+++ b/tests/Common/ManagerLogicTestTrait.php
@@ -498,12 +498,12 @@ trait ManagerLogicTestTrait
         $manager = $this->createFilledManager();
 
         $this->assertEqualsCanonicalizing(
-            ['admin', 'reader', 'author'],
+            ['reader', 'author'],
             array_keys($manager->getChildRoles('admin'))
         );
     }
 
-    public function testGetChildRolesUnknownRole(): void
+    public function testGetChildRolesWithNonExistingRole(): void
     {
         $manager = $this->createFilledManager();
 
@@ -513,7 +513,7 @@ trait ManagerLogicTestTrait
         $manager->getChildRoles('unknown');
     }
 
-    public function testGetPermissionsByRole(): void
+    public function testGetPermissionsByRoleName(): void
     {
         $manager = $this->createFilledManager();
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
