### PR TITLE
Use snake case for item attribute names (ease migration from Yii 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Bug #221: Exclude items with base names when getting children (@arogachev)
 - Bug #222: Adjust hierarchy when removing item (@arogachev)
 - Bug #223: Handle empty assignments in `Manager::getPermissionsByUserId()` (@arogachev)
+- Enh #227: Use snake case for item attribute names (ease migration from Yii 2) (@arogachev)
 
 ## 1.0.2 April 20, 2023
 

--- a/src/Item.php
+++ b/src/Item.php
@@ -139,10 +139,10 @@ abstract class Item
      * @psalm-return array{
      *     name:string,
      *     description:string,
-     *     ruleName:string|null,
+     *     rule_name:string|null,
      *     type:string,
-     *     updatedAt:int|null,
-     *     createdAt:int|null,
+     *     updated_at:int|null,
+     *     created_at:int|null,
      * }
      */
     final public function getAttributes(): array

--- a/src/Item.php
+++ b/src/Item.php
@@ -150,10 +150,10 @@ abstract class Item
         return [
             'name' => $this->getName(),
             'description' => $this->getDescription(),
-            'ruleName' => $this->getRuleName(),
+            'rule_name' => $this->getRuleName(),
             'type' => $this->getType(),
-            'updatedAt' => $this->getUpdatedAt(),
-            'createdAt' => $this->getCreatedAt(),
+            'updated_at' => $this->getUpdatedAt(),
+            'created_at' => $this->getCreatedAt(),
         ];
     }
 }

--- a/tests/Common/AssignmentsStorageTestTrait.php
+++ b/tests/Common/AssignmentsStorageTestTrait.php
@@ -270,25 +270,25 @@ trait AssignmentsStorageTestTrait
         ];
         $items = array_map(
             static function (array $item) use ($time): array {
-                $item['createdAt'] = $time;
-                $item['updatedAt'] = $time;
+                $item['created_at'] = $time;
+                $item['updated_at'] = $time;
 
                 return $item;
             },
             $items,
         );
         $assignments = [
-            ['itemName' => 'Researcher', 'userId' => 'john'],
-            ['itemName' => 'Accountant', 'userId' => 'john'],
-            ['itemName' => 'Quality control specialist', 'userId' => 'john'],
-            ['itemName' => 'Operator', 'userId' => 'jack'],
-            ['itemName' => 'Manager', 'userId' => 'jack'],
-            ['itemName' => 'Support specialist', 'userId' => 'jack'],
-            ['itemName' => 'Operator', 'userId' => 'jeff'],
+            ['item_name' => 'Researcher', 'user_id' => 'john'],
+            ['item_name' => 'Accountant', 'user_id' => 'john'],
+            ['item_name' => 'Quality control specialist', 'user_id' => 'john'],
+            ['item_name' => 'Operator', 'user_id' => 'jack'],
+            ['item_name' => 'Manager', 'user_id' => 'jack'],
+            ['item_name' => 'Support specialist', 'user_id' => 'jack'],
+            ['item_name' => 'Operator', 'user_id' => 'jeff'],
         ];
         $assignments = array_map(
             static function (array $item) use ($time): array {
-                $item['createdAt'] = $time;
+                $item['created_at'] = $time;
 
                 return $item;
             },
@@ -304,8 +304,8 @@ trait AssignmentsStorageTestTrait
             $name = $itemData['name'];
             $item = $itemData['type'] === Item::TYPE_PERMISSION ? new Permission($name) : new Role($name);
             $item = $item
-                ->withCreatedAt($itemData['createdAt'])
-                ->withUpdatedAt($itemData['updatedAt']);
+                ->withCreatedAt($itemData['created_at'])
+                ->withUpdatedAt($itemData['updated_at']);
             $this->getItemsStorage()->add($item);
         }
     }
@@ -315,8 +315,8 @@ trait AssignmentsStorageTestTrait
         foreach ($this->getFixtures()['assignments'] as $assignmentData) {
             $this->getAssignmentsStorage()->add(
                 new Assignment(
-                    userId: $assignmentData['userId'],
-                    itemName: $assignmentData['itemName'],
+                    userId: $assignmentData['user_id'],
+                    itemName: $assignmentData['item_name'],
                     createdAt: time(),
                 ),
             );

--- a/tests/Common/ItemsStorageTestTrait.php
+++ b/tests/Common/ItemsStorageTestTrait.php
@@ -601,8 +601,8 @@ trait ItemsStorageTestTrait
             $items[] = [
                 'name' => $name,
                 'type' => $type,
-                'createdAt' => $time,
-                'updatedAt' => $time,
+                'created_at' => $time,
+                'updated_at' => $time,
             ];
             $type === Item::TYPE_ROLE ? $this->initialRolesCount++ : $this->initialPermissionsCount++;
         }
@@ -652,8 +652,8 @@ trait ItemsStorageTestTrait
             $name = $itemData['name'];
             $item = $itemData['type'] === Item::TYPE_PERMISSION ? new Permission($name) : new Role($name);
             $item = $item
-                ->withCreatedAt($itemData['createdAt'])
-                ->withUpdatedAt($itemData['updatedAt']);
+                ->withCreatedAt($itemData['created_at'])
+                ->withUpdatedAt($itemData['updated_at']);
             $storage->add($item);
         }
 

--- a/tests/Common/ManagerLogicTestTrait.php
+++ b/tests/Common/ManagerLogicTestTrait.php
@@ -631,10 +631,10 @@ trait ManagerLogicTestTrait
             [
                 'name' => 'new role',
                 'description' => 'new role description',
-                'ruleName' => EasyRule::class,
+                'rule_name' => EasyRule::class,
                 'type' => 'role',
-                'updatedAt' => 1_642_026_148,
-                'createdAt' => 1_642_026_147,
+                'updated_at' => 1_642_026_148,
+                'created_at' => 1_642_026_147,
             ],
             $storedRole->getAttributes()
         );
@@ -696,10 +696,10 @@ trait ManagerLogicTestTrait
             [
                 'name' => 'edit post',
                 'description' => 'edit a post',
-                'ruleName' => null,
+                'rule_name' => null,
                 'type' => 'permission',
-                'updatedAt' => 1_642_026_148,
-                'createdAt' => 1_642_026_147,
+                'updated_at' => 1_642_026_148,
+                'created_at' => 1_642_026_147,
             ],
             $storedPermission->getAttributes()
         );

--- a/tests/PermissionTest.php
+++ b/tests/PermissionTest.php
@@ -32,10 +32,10 @@ final class PermissionTest extends TestCase
         $this->assertSame([
             'name' => 'test',
             'description' => '',
-            'ruleName' => null,
+            'rule_name' => null,
             'type' => Item::TYPE_PERMISSION,
-            'updatedAt' => null,
-            'createdAt' => null,
+            'updated_at' => null,
+            'created_at' => null,
         ], $permission->getAttributes());
     }
 }

--- a/tests/RoleTest.php
+++ b/tests/RoleTest.php
@@ -33,10 +33,10 @@ final class RoleTest extends TestCase
         $this->assertSame([
             'name' => 'test',
             'description' => '',
-            'ruleName' => null,
+            'rule_name' => null,
             'type' => Item::TYPE_ROLE,
-            'updatedAt' => null,
-            'createdAt' => null,
+            'updated_at' => null,
+            'created_at' => null,
         ], $permission->getAttributes());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

Related - https://github.com/yiisoft/rbac-cycle-db/issues/77.
