### PR TITLE
Concurrency in items storage tests, handle not found base item in access tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Bug #223: Handle empty assignments in `Manager::getPermissionsByUserId()` (@arogachev)
 - Enh #227: Use snake case for item attribute names (ease migration from Yii 2) (@arogachev)
 - New #230: Add `Assignment::getAttributes()` method (@arogachev)
+- Bug #237: Handle not found base item in access tree (@arogachev)
 
 ## 1.0.2 April 20, 2023
 

--- a/src/SimpleItemsStorage.php
+++ b/src/SimpleItemsStorage.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Yiisoft\Rbac;
 
+use RuntimeException;
+
 /**
  * @psalm-type RawItem = array{
  *      type: Item::TYPE_*,
@@ -108,6 +110,10 @@ abstract class SimpleItemsStorage implements ItemsStorageInterface
 
     public function getAccessTree(string $name): array
     {
+        if (!array_key_exists($name, $this->items)) {
+            throw new RuntimeException('Base item not found.');
+        }
+
         $result = [$name => ['item' => $this->items[$name], 'children' => []]];
         $this->fillAccessTreeRecursive($name, $result);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
